### PR TITLE
Update create.class.php - pre-complete fieldsin resource

### DIFF
--- a/manager/controllers/default/resource/create.class.php
+++ b/manager/controllers/default/resource/create.class.php
@@ -105,6 +105,14 @@ class ResourceCreateManagerController extends ResourceManagerController {
                 'cacheable' => $this->context->getOption('cache_default', 1, $this->modx->_userConfig),
                 'syncsite' => true,
             ));
+            
+            $newValuesArr = Array();
+            $allowedFields = Array('pagetitle','longtitle','description','introtext','content','link_attributes','alias','menutitle');
+            foreach ($allowedFields as $field) {
+                $newValuesArr[$field] = $this->resource->get($field);
+            }
+            $this->resourceArray = array_merge($this->resourceArray, $newValuesArr);
+            
             $this->parent->fromArray($this->resourceArray);
             $this->parent->set('template',$defaultTemplate);
             $this->resource->set('template',$defaultTemplate);


### PR DESCRIPTION
This patch gives possibility to use $resource variable in plugin with "OnDocFormRender" event to predefine some inputs, when creating new resource (or update existing one).

So, if in plugin with "OnDocFormRender" we use:
```php
$resource->set('content',"Hey, i'm default content! You can change me to anything you want...");
```
then we get pre filled "content" field after "New resource" or "Update Resource" click.

Fields, which can be pre filled:

* pagetitle
* longtitle
* description
* introtext
* content
* link_attributes
* alias
* menutitle

**1. Data will NOT be saved into database until click "save" button!
2. If you update resource, remember that, this overwrite your content received from database (you'll see this *Hey, i'm default content...* text rather than received one!**